### PR TITLE
Build PRU firmware without CCS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Debug/
 Release/
 .xdchelp
+gen/

--- a/src/firmware/ths1206/pru0/Makefile
+++ b/src/firmware/ths1206/pru0/Makefile
@@ -1,0 +1,110 @@
+# This file is a slightly modified version of:
+# Makefile to make PRU_inlineASM_blinky project
+# Copyright (c) 2016 Zubeen Tolani <ZeekHuge - zeekhuge@gmail.com>
+#
+
+# PRU_CGT environment variable must point to the TI PRU compiler directory
+#
+# PRU_SUPPORT environment variable must point to PRU software support package 
+#             providing header files such as rsc_types.h
+
+ifndef PRU_CGT
+define ERROR_BODY
+
+************************************************************
+PRU_CGT environment variable is not set. Example:
+  export PRU_CGT=/opt/ti/ti-cgt-pru_2.1.0
+
+Download for PRU code generation tools
+http://software-dl.ti.com/codegen/non-esd/downloads/download.htm#PRU
+************************************************************
+
+endef
+$(error $(ERROR_BODY))
+endif
+
+ifndef PRU_SUPPORT
+define ERROR_BODY
+
+************************************************************
+PRU_SUPPORT environment variable is not set. Example:
+  export PRU_SUPPORT=/opt/ti/pru-software-support-package
+
+Download for PRU software support package 
+https://github.com/jadonk/pru-software-support-package
+************************************************************
+
+endef
+$(error $(ERROR_BODY))
+endif
+
+MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
+CURRENT_DIR := $(notdir $(patsubst %/,%,$(dir $(MKFILE_PATH))))
+PROJ_NAME=$(CURRENT_DIR)
+LINKER_COMMAND_FILE=./AM335x_PRU.cmd
+#LIBS=--library=../../../lib/rpmsg_lib.lib
+INCLUDE=--include_path=$(PRU_CGT)/include --include_path=$(PRU_SUPPORT)/include
+STACK_SIZE=0x100
+HEAP_SIZE=0x100
+GEN_DIR=gen
+
+#Common compiler and linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+CFLAGS=-v3 -O2 --display_error_number --endian=little --hardware_mac=on --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) -ppd -ppa
+#Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS=--reread_libs --warn_sections --stack_size=$(STACK_SIZE) --heap_size=$(HEAP_SIZE)
+
+TARGET=$(GEN_DIR)/$(PROJ_NAME).out
+MAP=$(GEN_DIR)/$(PROJ_NAME).map
+SOURCES=$(wildcard *.c)
+#Using .object instead of .obj in order to not conflict with the CCS build process
+OBJECTS=$(patsubst %,$(GEN_DIR)/%,$(SOURCES:.c=.object))
+
+all: printStart $(TARGET) printEnd
+
+printStart:
+	@echo ''
+	@echo '************************************************************'
+	@echo 'Building project: $(PROJ_NAME)'
+
+printEnd:
+	@echo ''
+	@echo 'Finished building project: $(PROJ_NAME)'
+	@echo '************************************************************'
+	@echo ''
+
+# Invokes the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(LINKER_COMMAND_FILE)
+	@echo ''
+	@echo 'Building target: $@'
+	@echo 'Invoking: PRU Linker'
+	$(PRU_CGT)/bin/clpru $(CFLAGS) -z -i$(PRU_CGT)/lib -i$(PRU_CGT)/include $(LFLAGS) -o $(TARGET) $(OBJECTS) -m$(MAP) $(LINKER_COMMAND_FILE) --library=libc.a $(LIBS)
+	@echo 'Finished building target: $@'
+	@echo ''
+	@echo 'Output files can be found in the "$(GEN_DIR)" directory'
+
+# Invokes the compiler on all c files in the directory to create the object files
+$(GEN_DIR)/%.object: %.c
+	@mkdir -p $(GEN_DIR)
+	@echo ''
+	@echo 'Building file: $<'
+	@echo 'Invoking: PRU Compiler'
+	$(PRU_CGT)/bin/clpru --include_path=$(PRU_CGT)/include $(INCLUDE) $(CFLAGS) -fe $@ $<
+
+.PHONY: all clean
+
+# Remove the $(GEN_DIR) directory
+clean:
+	@echo ''
+	@echo '************************************************************'
+	@echo 'Cleaning project: $(PROJ_NAME)'
+	@echo ''
+	@echo 'Removing files in the "$(GEN_DIR)" directory'
+	@rm -rf $(GEN_DIR)
+	@echo ''
+	@echo 'Finished cleaning project: $(PROJ_NAME)'
+	@echo '************************************************************'
+	@echo ''
+
+# Includes the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.object=%.pp)
+

--- a/src/firmware/ths1206/pru1/Makefile
+++ b/src/firmware/ths1206/pru1/Makefile
@@ -1,0 +1,110 @@
+# This file is a slightly modified version of:
+# Makefile to make PRU_inlineASM_blinky project
+# Copyright (c) 2016 Zubeen Tolani <ZeekHuge - zeekhuge@gmail.com>
+#
+
+# PRU_CGT environment variable must point to the TI PRU compiler directory
+#
+# PRU_SUPPORT environment variable must point to PRU software support package 
+#             providing header files such as rsc_types.h
+
+ifndef PRU_CGT
+define ERROR_BODY
+
+************************************************************
+PRU_CGT environment variable is not set. Example:
+  export PRU_CGT=/opt/ti/ti-cgt-pru_2.1.0
+
+Download for PRU code generation tools
+http://software-dl.ti.com/codegen/non-esd/downloads/download.htm#PRU
+************************************************************
+
+endef
+$(error $(ERROR_BODY))
+endif
+
+ifndef PRU_SUPPORT
+define ERROR_BODY
+
+************************************************************
+PRU_SUPPORT environment variable is not set. Example:
+  export PRU_SUPPORT=/opt/ti/pru-software-support-package
+
+Download for PRU software support package 
+https://github.com/jadonk/pru-software-support-package
+************************************************************
+
+endef
+$(error $(ERROR_BODY))
+endif
+
+MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
+CURRENT_DIR := $(notdir $(patsubst %/,%,$(dir $(MKFILE_PATH))))
+PROJ_NAME=$(CURRENT_DIR)
+LINKER_COMMAND_FILE=./AM335x_PRU.cmd
+#LIBS=--library=../../../lib/rpmsg_lib.lib
+INCLUDE=--include_path=$(PRU_CGT)/include --include_path=$(PRU_SUPPORT)/include
+STACK_SIZE=0x100
+HEAP_SIZE=0x100
+GEN_DIR=gen
+
+#Common compiler and linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+CFLAGS=-v3 -O2 --display_error_number --endian=little --hardware_mac=on --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) -ppd -ppa
+#Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS=--reread_libs --warn_sections --stack_size=$(STACK_SIZE) --heap_size=$(HEAP_SIZE)
+
+TARGET=$(GEN_DIR)/$(PROJ_NAME).out
+MAP=$(GEN_DIR)/$(PROJ_NAME).map
+SOURCES=$(wildcard *.c)
+#Using .object instead of .obj in order to not conflict with the CCS build process
+OBJECTS=$(patsubst %,$(GEN_DIR)/%,$(SOURCES:.c=.object))
+
+all: printStart $(TARGET) printEnd
+
+printStart:
+	@echo ''
+	@echo '************************************************************'
+	@echo 'Building project: $(PROJ_NAME)'
+
+printEnd:
+	@echo ''
+	@echo 'Finished building project: $(PROJ_NAME)'
+	@echo '************************************************************'
+	@echo ''
+
+# Invokes the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(LINKER_COMMAND_FILE)
+	@echo ''
+	@echo 'Building target: $@'
+	@echo 'Invoking: PRU Linker'
+	$(PRU_CGT)/bin/clpru $(CFLAGS) -z -i$(PRU_CGT)/lib -i$(PRU_CGT)/include $(LFLAGS) -o $(TARGET) $(OBJECTS) -m$(MAP) $(LINKER_COMMAND_FILE) --library=libc.a $(LIBS)
+	@echo 'Finished building target: $@'
+	@echo ''
+	@echo 'Output files can be found in the "$(GEN_DIR)" directory'
+
+# Invokes the compiler on all c files in the directory to create the object files
+$(GEN_DIR)/%.object: %.c
+	@mkdir -p $(GEN_DIR)
+	@echo ''
+	@echo 'Building file: $<'
+	@echo 'Invoking: PRU Compiler'
+	$(PRU_CGT)/bin/clpru --include_path=$(PRU_CGT)/include $(INCLUDE) $(CFLAGS) -fe $@ $<
+
+.PHONY: all clean
+
+# Remove the $(GEN_DIR) directory
+clean:
+	@echo ''
+	@echo '************************************************************'
+	@echo 'Cleaning project: $(PROJ_NAME)'
+	@echo ''
+	@echo 'Removing files in the "$(GEN_DIR)" directory'
+	@rm -rf $(GEN_DIR)
+	@echo ''
+	@echo 'Finished cleaning project: $(PROJ_NAME)'
+	@echo '************************************************************'
+	@echo ''
+
+# Includes the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.object=%.pp)
+


### PR DESCRIPTION
Borrow one of the nice Makefiles from BeagleScope firmware examples
https://github.com/ZeekHuge/BeagleScope

Slight modification was needed to point to an external copy
of rsc_types.h header in pru-software-support-package
(I suspect CCS comes with these headers included)
https://github.com/jadonk/pru-software-support-package
